### PR TITLE
flask-restful 0.3.10 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,25 @@
-{% set name = "Flask-RESTful" %}
-{% set version = "0.3.9" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash_val = "ccec650b835d48192138c85329ae03735e6ced58e9b2d9c2146d6c84c06fa53e" %}
-{% set build = 0 %}
+{% set name = "flask-restful" %}
+{% set pkg_name = "Flask-RESTful" %}
+{% set version = "0.3.10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash_val }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ pkg_name }}-{{ version }}.tar.gz
+  sha256: fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37
 
 build:
-  number: {{ build }}
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
     - wheel
-
+    - setuptools
   run:
     - python
     - aniso8601 >=0.82
@@ -32,26 +27,44 @@ requirements:
     - six >=1.3.0
     - pytz
 
+# >   self.assertEqual(resp.headers['Location'], 'http://localhost/')
+# E   AssertionError: '/' != 'http://localhost/'
+# E   - /
+# E   + http://localhost/
+{% set deselect_tests = " --deselect=tests/test_api.py::APITestCase::test_redirect" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_fields.py::FieldsTestCase::test_iso8601_date_field_with_offset" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_fields.py::FieldsTestCase::test_rfc822_date_field_with_offset" %}
+
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
+  source_files:
+    - tests
   imports:
     - flask_restful
     - flask_restful.representations
     - flask_restful.utils
+  commands:
+    - pip check
+    - pytest -v tests {{ deselect_tests }}
+  requires:
+    - pip
+    # 'yield' keyword is allowed in fixtures, but not in tests, upper bound added
+    - pytest <7
+    # E   ImportError: cannot import name 'signals_available' from 'flask.signals', upper bound added
+    - flask <3
+    - mock >=0.8
+    - nose
+    - blinker
+    # E   werkzeug.exceptions.UnsupportedMediaType: 415 Unsupported Media Type: Did not attempt to load JSON data because the request Content-Type was not 'application/json'.
+    - werkzeug <2.1
 
 about:
-  home: https://github.com/flask-restful/flask-restful/
+  home: https://github.com/flask-restful/flask-restful
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
-  license_url: https://github.com/flask-restful/flask-restful/blob/master/LICENSE
-  summary: 'Simple framework for creating REST APIs'
-  doc_url: https://flask-restful.readthedocs.io/en/latest/
-  dev_url: https://github.com/flask-restful/flask-restful/
-  doc_source_url: https://github.com/flask-restful/flask-restful/blob/master/docs/index.rst
+  summary: Simple framework for creating REST APIs
+  doc_url: https://flask-restful.readthedocs.io
+  dev_url: https://github.com/flask-restful/flask-restful
   description: |
     Flask-RESTful is an extension for Flask that adds support
     for quickly building REST APIs. It is a lightweight

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,12 @@ requirements:
 # E   - /
 # E   + http://localhost/
 {% set deselect_tests = " --deselect=tests/test_api.py::APITestCase::test_redirect" %}
+# >   self.assertEqual("Mon, 22 Aug 2011 19:58:45 -0000", field.output("bar", obj))
+# E   AssertionError: 'Mon, 22 Aug 2011 19:58:45 -0000' != 'Mon, 22 Aug 2011 20:40:45 -0000'
+# E   - Mon, 22 Aug 2011 19:58:45 -0000
+# E   ?                  ^^ ^^
+# E   + Mon, 22 Aug 2011 20:40:45 -0000
+# E   ?                  ^^ ^
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_fields.py::FieldsTestCase::test_iso8601_date_field_with_offset" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_fields.py::FieldsTestCase::test_rfc822_date_field_with_offset" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,11 @@ test:
     - flask_restful.utils
   commands:
     - pip check
-    - pytest -v tests {{ deselect_tests }}
+    # ModuleNotFoundError: No module named 'imp' for py>311
+    # In Python from 3.12 there is no module called imp. Instead of use importlib as:
+    # from importlib import import_module
+    # https://docs.python.org/3/whatsnew/3.12.html#imp
+    - pytest -v tests {{ deselect_tests }}  # [py<312]
   requires:
     - pip
     # 'yield' keyword is allowed in fixtures, but not in tests, upper bound added


### PR DESCRIPTION
flask-restful 0.3.10 

**Destination channel:** Defaults

### Links

- [PKG-9600]
- dev_url:        https://github.com/flask-restful/flask-restful//tree/0.3.10
- conda_forge:    https://github.com/conda-forge/flask-restful-feedstock
- pypi:           https://pypi.org/project/flask-restful/0.3.10
- pypi inspector: https://inspector.pypi.io/project/flask-restful/0.3.10

### Explanation of changes:

- new version number


[PKG-9600]: https://anaconda.atlassian.net/browse/PKG-9600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ